### PR TITLE
Fix bookmark from singer as a string

### DIFF
--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -327,6 +327,10 @@ class UsersStream(SlackStream):
                                        key=self.replication_key)
         if bookmark is None:
             bookmark = strptime_to_utc(self.config.get('start_date'))
+        else:
+            # bookmark from singer is a string
+            bookmark = strptime_to_utc(bookmark)
+
         new_bookmark = bookmark
 
         # pylint: disable=unused-variable


### PR DESCRIPTION
# Description of change
When you get the bookmark from singer, it is a string.  You have to convert it to a datetime to be able to compare it from the API.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
